### PR TITLE
v0.4 — Cache coverage data for non-executed test files. Introducing adapters.

### DIFF
--- a/adapters/mocha.js
+++ b/adapters/mocha.js
@@ -1,0 +1,71 @@
+'use strict'
+/* global mocha, describe, before, after */
+
+exports.setup = function (options) {
+  options = options || { ui: 'bdd' }
+
+  // Create an element for Mocha.
+  var mochaElement = document.createElement('div')
+  mochaElement.id = 'mocha'
+  document.body.appendChild(mochaElement)
+
+  // Require browser version of Mocha.
+  require('script!mocha/mocha.js')
+  require('style!raw!mocha/mocha.css')
+
+  // Set up the interfaces.
+  mocha.setup(options)
+}
+
+exports.run = function (options) {
+  var context = options.context
+  var TestBed = require('../src/test-bed')
+
+  TestBed.run({
+    context: context,
+
+    // This function is called when test-bed finished loading all dependencies.
+    runTests: function () {
+      return new Promise(function (resolve) {
+        var runner = mocha.run(resolve)
+        var _testing = false
+
+        // Listen to 'test' and 'test end' events and report to test-bed to
+        // capture code coverage data.
+        runner.on('suite', function (suite) {
+          if (suite._testBedKey) {
+            TestBed.fileStarted(suite._testBedKey)
+          }
+        })
+        runner.on('suite end', function (suite) {
+          if (suite._testBedKey) {
+            TestBed.fileEnded(suite._testBedKey)
+          }
+        })
+        runner.on('test', function (test) {
+          _testing = true
+          TestBed.testStarted(test.fullTitle())
+        })
+        runner.on('test end', function (test) {
+          if (!_testing) return
+          _testing = false
+          TestBed.testEnded(test.fullTitle())
+        })
+      })
+    },
+
+    // This function is called when test-bed wants to `require()` a test file.
+    //
+    // * `key` is the test file name.
+    // * `doRequire` is a function that, when called, will require that test file.
+    //
+    // This function should be used synchronously.
+    //
+    wrapRequire: function (key, doRequire) {
+      describe(key, function () {
+        this._testBedKey = key
+        doRequire()
+      })
+    }
+  })
+}

--- a/adapters/mocha.js
+++ b/adapters/mocha.js
@@ -10,8 +10,8 @@ exports.setup = function (options) {
   document.body.appendChild(mochaElement)
 
   // Require browser version of Mocha.
-  require('script!mocha/mocha.js')
-  require('style!raw!mocha/mocha.css')
+  require('!!script!mocha/mocha.js')
+  require('!!style!raw!mocha/mocha.css')
 
   // Set up the interfaces.
   mocha.setup(options)

--- a/coverageReportWriter.js
+++ b/coverageReportWriter.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const debug = require('debug')('test-bed:coverageReportWriter')
+
+process.on('message', function (cache) {
+  debug('Received cache from parent process.')
+  require('./writeCoverageReport')(cache, function () {
+    debug('Done')
+    process.exit(0)
+  })
+})
+
+debug('Initialized')

--- a/createCoverageSaver.js
+++ b/createCoverageSaver.js
@@ -1,5 +1,7 @@
+'use strict'
 
 module.exports = function createCoverageSaver () {
+  const debug = require('debug')('test-bed:coverageSaver')
   const cache = { }
 
   function receiveReport (report) {
@@ -11,13 +13,17 @@ module.exports = function createCoverageSaver () {
       const files = report.files
       for (const key of Object.keys(cache)) {
         if (key === '(runtime)') continue
-        if (files.indexOf(key) === -1) delete cache[key]
+        if (files.indexOf(key) === -1) {
+          debug('Pruning cache for: %s.', key)
+          delete cache[key]
+        }
       }
     }
 
     function storeCoverageData () {
       const collectedData = report.collectedData
       for (const key of Object.keys(collectedData)) {
+        debug('Storing coverage data for: %s.', key)
         cache[key] = collectedData[key]
       }
     }
@@ -29,7 +35,7 @@ module.exports = function createCoverageSaver () {
     const reporter = new istanbul.Reporter()
     for (const key of Object.keys(cache)) {
       for (const entry of cache[key]) {
-        // console.log('Adding coverage data of %s -> %s', key, entry.test)
+        debug('Adding coverage data of %s -> %s', key, entry.test)
         collector.add(entry.snapshot)
       }
     }

--- a/createCoverageSaver.js
+++ b/createCoverageSaver.js
@@ -30,19 +30,8 @@ module.exports = function createCoverageSaver () {
   }
 
   function writeCoverageReport () {
-    const istanbul = require('istanbul')
-    const collector = new istanbul.Collector()
-    const reporter = new istanbul.Reporter()
-    for (const key of Object.keys(cache)) {
-      for (const entry of cache[key]) {
-        debug('Adding coverage data of %s -> %s', key, entry.test)
-        collector.add(entry.snapshot)
-      }
-    }
-    reporter.add('lcovonly')
-    reporter.write(collector, false, function () {
-      // saved coverage report!!!
-    })
+    const reportWriter = require('child_process').fork(require.resolve('./coverageReportWriter'))
+    reportWriter.send(cache)
   }
 
   return { receiveReport }

--- a/createCoverageSaver.js
+++ b/createCoverageSaver.js
@@ -1,0 +1,43 @@
+
+module.exports = function createCoverageSaver () {
+  const cache = { }
+
+  function receiveReport (report) {
+    pruneCacheEntriesNotInFiles()
+    storeCoverageData()
+    writeCoverageReport()
+
+    function pruneCacheEntriesNotInFiles () {
+      const files = report.files
+      for (const key of Object.keys(cache)) {
+        if (key === '(runtime)') continue
+        if (files.indexOf(key) === -1) delete cache[key]
+      }
+    }
+
+    function storeCoverageData () {
+      const collectedData = report.collectedData
+      for (const key of Object.keys(collectedData)) {
+        cache[key] = collectedData[key]
+      }
+    }
+  }
+
+  function writeCoverageReport () {
+    const istanbul = require('istanbul')
+    const collector = new istanbul.Collector()
+    const reporter = new istanbul.Reporter()
+    for (const key of Object.keys(cache)) {
+      for (const entry of cache[key]) {
+        // console.log('Adding coverage data of %s -> %s', key, entry.test)
+        collector.add(entry.snapshot)
+      }
+    }
+    reporter.add('lcovonly')
+    reporter.write(collector, false, function () {
+      // saved coverage report!!!
+    })
+  }
+
+  return { receiveReport }
+}

--- a/createServer.js
+++ b/createServer.js
@@ -5,6 +5,7 @@ const path = require('path')
 const createCoverageSaver = require('./createCoverageSaver')
 
 function createCompiler (inConfig) {
+  const debug = require('debug')('test-bed:compiler')
   const webpack = require('webpack')
   const config = Object.assign({ }, inConfig)
 
@@ -38,7 +39,10 @@ function createCompiler (inConfig) {
   config.plugins = plugins
 
   function ensurePlugin (Plugin) {
-    if (!plugins.some(plugin => plugin instanceof Plugin)) {
+    if (plugins.some(plugin => plugin instanceof Plugin)) {
+      debug('%s already exists in webpack configuration, skipping.', Plugin.name)
+    } else {
+      debug('Adding %s to configuration.', Plugin.name)
       plugins.push(new Plugin())
     }
   }
@@ -47,6 +51,7 @@ function createCompiler (inConfig) {
 }
 
 module.exports = function createServer (config) {
+  const debug = require('debug')('test-bed:server')
   const express = require('express')
   const app = express()
   const server = require('http').createServer(app)
@@ -67,6 +72,8 @@ module.exports = function createServer (config) {
     const builtModules = findBuiltModules()
     const affectedModuleIds = calculateAffectedModuleIds(builtModules)
     const errors = stats.toJson().errors || [ ]
+    debug('Built modules: %o', builtModules.map(builtModule => builtModule.id))
+    debug('Affected modules: %o', affectedModuleIds)
 
     io.emit('compiled', {
       affectedModuleIds,

--- a/createServer.js
+++ b/createServer.js
@@ -81,8 +81,12 @@ module.exports = function createServer (config) {
     })
 
     io.on('connection', function (socket) {
-      socket.on('coverage', function (report) {
+      function saveCoverage (report) {
         coverageSaver.receiveReport(report)
+      }
+      socket.on('coverage', saveCoverage)
+      socket.on('disconnect', function () {
+        socket.removeListener('coverage', saveCoverage)
       })
     })
 

--- a/createServer.js
+++ b/createServer.js
@@ -2,6 +2,7 @@
 'use strict'
 
 const path = require('path')
+const createCoverageSaver = require('./createCoverageSaver')
 
 function createCompiler (inConfig) {
   const webpack = require('webpack')
@@ -51,6 +52,7 @@ module.exports = function createServer (config) {
   const server = require('http').createServer(app)
   const io = require('socket.io')(server)
   const compiler = createCompiler(config)
+  const coverageSaver = createCoverageSaver()
 
   app.use(express.static(path.resolve(__dirname, 'static')))
 
@@ -72,15 +74,8 @@ module.exports = function createServer (config) {
     })
 
     io.on('connection', function (socket) {
-      socket.on('coverage', function (coverageData) {
-        const istanbul = require('istanbul')
-        const collector = new istanbul.Collector()
-        const reporter = new istanbul.Reporter()
-        collector.add(coverageData)
-        reporter.add('lcovonly')
-        reporter.write(collector, false, function () {
-          // saved coverage report!!!
-        })
+      socket.on('coverage', function (report) {
+        coverageSaver.receiveReport(report)
       })
     })
 

--- a/example/src/add.js
+++ b/example/src/add.js
@@ -1,2 +1,4 @@
 
-export default (a, b) => a + b
+export default (a, b) => {
+  return a + b
+}

--- a/example/src/multiply.js
+++ b/example/src/multiply.js
@@ -1,2 +1,4 @@
 
-export default (a, b) => a * b
+export default (a, b) => {
+  return a * b
+}

--- a/example/src/repeat.js
+++ b/example/src/repeat.js
@@ -1,3 +1,10 @@
 
-const repeat = (f, n) => (x) => n > 0 ? f(repeat(f, n - 1)(x)) : x
+const repeat = (f, n) => (x) => {
+  if (n > 0) {
+    return f(repeat(f, n - 1)(x))
+  } else {
+    return x
+  }
+}
+
 export default repeat

--- a/example/src/test-entry.js
+++ b/example/src/test-entry.js
@@ -1,43 +1,12 @@
 
 // Setup mocha
-{
-  const mochaElement = document.createElement('div')
-  mochaElement.id = 'mocha'
-  document.body.appendChild(mochaElement)
-
-  require('script!mocha/mocha.js')
-  require('style!css!mocha/mocha.css')
-
-  mocha.setup({ ui: 'bdd' })
-}
+var TestBedMocha = require('test-bed/adapters/mocha')
+TestBedMocha.setup()
 
 // Setup power-assert
-{
-  global.assert = require('power-assert')
-}
+global.assert = require('power-assert')
 
 // Setup TestBed
-TestBed.run({
-  context: require.context('.', true, /\.spec\.js$/),
-  runTests: () => new Promise((resolve, reject) => {
-    const runner = mocha.run((err) => resolve())
-    let _testing = false
-    runner.on('test', function (test) {
-      _testing = true
-      TestBed.testStarted(test.fullTitle())
-    })
-    runner.on('test end', function (test) {
-      if (!_testing) return
-      _testing = false
-      TestBed.testEnded(test.fullTitle())
-    })
-  }),
-  wrapRequire (key, doRequire) {
-    describe(key, function () {
-      before(function () {
-        TestBed.fileStarted(key)
-      })
-      doRequire()
-    })
-  }
+TestBedMocha.run({
+  context: require.context('.', true, /\.spec\.js$/)
 })

--- a/example/src/test-entry.js
+++ b/example/src/test-entry.js
@@ -6,7 +6,7 @@ TestBedMocha.setup()
 // Setup power-assert
 global.assert = require('power-assert')
 
-// Setup TestBed
+// Run the tests
 TestBedMocha.run({
   context: require.context('.', true, /\.spec\.js$/)
 })

--- a/example/src/test-entry.js
+++ b/example/src/test-entry.js
@@ -20,6 +20,24 @@
 TestBed.run({
   context: require.context('.', true, /\.spec\.js$/),
   runTests: () => new Promise((resolve, reject) => {
-    mocha.run((err) => resolve())
-  })
+    const runner = mocha.run((err) => resolve())
+    let _testing = false
+    runner.on('test', function (test) {
+      _testing = true
+      TestBed.testStarted(test.fullTitle())
+    })
+    runner.on('test end', function (test) {
+      if (!_testing) return
+      _testing = false
+      TestBed.testEnded(test.fullTitle())
+    })
+  }),
+  wrapRequire (key, doRequire) {
+    describe(key, function () {
+      before(function () {
+        TestBed.fileStarted(key)
+      })
+      doRequire()
+    })
+  }
 })

--- a/example/webpack.config.test-bed.js
+++ b/example/webpack.config.test-bed.js
@@ -6,6 +6,12 @@ process.env.BABEL_ENV = 'test'
 
 module.exports = {
   entry: './src/test-entry.js',
+  resolve: {
+    alias: {
+      'test-bed$': path.resolve(__dirname, '../src/test-bed.js'),
+      'test-bed': path.resolve(__dirname, '..')
+    }
+  },
   module: {
     loaders: [
       {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.1",
   "description": "Development test runner for webpack-based apps. Runs only specs affected by code change. For improved TDD experience!",
   "main": "index.js",
-  "webpack": "src/test-bed.js",
+  "webpack": "runtime.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "publish-please": "publish-please",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.1",
   "description": "Development test runner for webpack-based apps. Runs only specs affected by code change. For improved TDD experience!",
   "main": "index.js",
+  "webpack": "src/test-bed.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "publish-please": "publish-please",
@@ -15,13 +16,18 @@
     "test-bed": "./index.js"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "express": "^4.13.4",
     "istanbul": "^0.4.3",
+    "raw-loader": "^0.5.1",
+    "script-loader": "^0.7.0",
     "socket.io": "^1.4.6",
+    "style-loader": "^0.13.1",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.10.0"
   },
   "devDependencies": {
+    "mocha": "^2.5.3",
     "publish-please": "^2.1.3",
     "standard": "^7.1.0",
     "webpack": "^2.1.0-beta.7"

--- a/runtime.js
+++ b/runtime.js
@@ -1,0 +1,1 @@
+module.exports = require('./src/test-bed')

--- a/src/coverageCollector.js
+++ b/src/coverageCollector.js
@@ -1,0 +1,96 @@
+var _currentFile = '(runtime)'
+var _currentTest = '(runtime)'
+var _snapshots = { }
+
+function takeCoverageDataSnapshot (coverageData) {
+  var snapshot = { }
+  var _empty = true
+  for (var fileName in coverageData) {
+    if (!isFileCoverageEmpty(coverageData[fileName])) {
+      snapshot[fileName] = JSON.parse(JSON.stringify(coverageData[fileName]))
+      _empty = false
+    }
+  }
+  if (_empty) return null
+  return snapshot
+}
+
+function clearCoverageData (coverageData) {
+  for (var fileName in coverageData) {
+    clearCoverageFileData(coverageData[fileName])
+  }
+}
+
+function clearCoverageFileData (fileData) {
+  var id
+  for (id in fileData.s) {
+    fileData.s[id] = 0
+  }
+  for (id in fileData.b) {
+    var a = fileData.b[id]
+    for (var i = 0; i < a.length; i++) a[i] = 0
+  }
+  for (id in fileData.f) {
+    fileData.f[id] = 0
+  }
+}
+
+function isFileCoverageEmpty (fileData) {
+  var id
+  for (id in fileData.s) {
+    if (fileData.s[id] > 0) return false
+  }
+  for (id in fileData.b) {
+    if (fileData.b[id].reduce(sum, 0) > 0) return false
+  }
+  for (id in fileData.f) {
+    if (fileData.f[id] > 0) return false
+  }
+  return true
+}
+
+function sum (a, b) {
+  return a + b
+}
+
+function createCoverageDataHandler (f) {
+  return function () {
+    if (global.__coverage__) return f(global.__coverage__).apply(this, arguments)
+  }
+}
+
+var doSwitch = createCoverageDataHandler(function (coverageData) {
+  return function (file, test) {
+    var snapshot = takeCoverageDataSnapshot(coverageData)
+    if (snapshot) {
+      clearCoverageData(coverageData)
+      var storage = _snapshots[_currentFile] || (_snapshots[_currentFile] = [ ])
+      var newData = { test: _currentTest, snapshot: snapshot }
+      storage.push(newData)
+      // console.log('Collected:', _currentFile, _currentTest, snapshot)
+    }
+    _currentFile = file
+    _currentTest = test
+  }
+})
+
+exports.fileStarted = function (key) {
+  doSwitch(key, _currentTest)
+}
+
+exports.fileEnded = function () {
+  doSwitch('(runtime)', _currentTest)
+}
+
+exports.testStarted = function (testName) {
+  doSwitch(_currentFile, testName)
+}
+
+exports.testEnded = function () {
+  doSwitch(_currentFile, '(runtime)')
+}
+
+exports.finalizeAndReturnCollectedCoverageData = function () {
+  doSwitch('(runtime)', '(runtime)')
+  return _snapshots
+}

--- a/src/coverageCollector.js
+++ b/src/coverageCollector.js
@@ -2,23 +2,24 @@ var _currentFile = '(runtime)'
 var _currentTest = '(runtime)'
 var _snapshots = { }
 
-function takeCoverageDataSnapshot (coverageData) {
+// NOTE: Optimized performance for hot code path.
+//
+// This function is quite complicated because it takes coverage
+// data snapshot AND clears it in one go, because for many files
+// doing these steps separately is slow and can add ~16ms per test.
+//
+function takeCoverageDataSnapshotAndClearData (coverageData) {
   var snapshot = { }
   var _empty = true
   for (var fileName in coverageData) {
     if (!isFileCoverageEmpty(coverageData[fileName])) {
       snapshot[fileName] = JSON.parse(JSON.stringify(coverageData[fileName]))
+      clearCoverageFileData(coverageData[fileName])
       _empty = false
     }
   }
   if (_empty) return null
   return snapshot
-}
-
-function clearCoverageData (coverageData) {
-  for (var fileName in coverageData) {
-    clearCoverageFileData(coverageData[fileName])
-  }
 }
 
 function clearCoverageFileData (fileData) {
@@ -28,7 +29,7 @@ function clearCoverageFileData (fileData) {
   }
   for (id in fileData.b) {
     var a = fileData.b[id]
-    for (var i = 0; i < a.length; i++) a[i] = 0
+    for (var i = 0, l = a.length; i < l; i++) a[i] = 0
   }
   for (id in fileData.f) {
     fileData.f[id] = 0
@@ -61,9 +62,8 @@ function createCoverageDataHandler (f) {
 
 var doSwitch = createCoverageDataHandler(function (coverageData) {
   return function (file, test) {
-    var snapshot = takeCoverageDataSnapshot(coverageData)
+    var snapshot = takeCoverageDataSnapshotAndClearData(coverageData)
     if (snapshot) {
-      clearCoverageData(coverageData)
       var storage = _snapshots[_currentFile] || (_snapshots[_currentFile] = [ ])
       var newData = { test: _currentTest, snapshot: snapshot }
       storage.push(newData)
@@ -83,11 +83,13 @@ exports.fileEnded = function () {
 }
 
 exports.testStarted = function (testName) {
-  doSwitch(_currentFile, testName)
+  // XXX: Disabled per-test coverage capturing due to unacceptable performance penalty for now.
+  // doSwitch(_currentFile, testName)
 }
 
 exports.testEnded = function () {
-  doSwitch(_currentFile, '(runtime)')
+  // XXX: Disabled per-test coverage capturing due to unacceptable performance penalty for now.
+  // doSwitch(_currentFile, '(runtime)')
 }
 
 exports.finalizeAndReturnCollectedCoverageData = function () {

--- a/src/test-bed.js
+++ b/src/test-bed.js
@@ -1,7 +1,7 @@
 const overlay = require('webpack-hot-middleware/client-overlay')
 const coverageCollector = require('./coverageCollector')
 
-window.TestBed = (function () {
+module.exports = (function () {
   var status = document.querySelector('#testbed-status')
 
   var maybeFrame = (function () {

--- a/writeCoverageReport.js
+++ b/writeCoverageReport.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const debug = require('debug')('test-bed:writeCoverageReport')
+
+function writeCoverageReport (cache, done) {
+  const istanbul = require('istanbul')
+  const collector = new istanbul.Collector()
+  const reporter = new istanbul.Reporter()
+  for (const key of Object.keys(cache)) {
+    for (const entry of cache[key]) {
+      debug('Adding coverage data of %s -> %s', key, entry.test)
+      collector.add(entry.snapshot)
+    }
+  }
+  reporter.add('lcovonly')
+  reporter.write(collector, false, done)
+}
+
+module.exports = writeCoverageReport


### PR DESCRIPTION
# v0.4

This release comes with better code coverage handling. More specifically, it will remember the test coverage of previously run tests. This mean you will always get a live coverage report as if all tests were run.

Help me test this out:

```
npm i --save-dev 'taskworld/test-bed#better-coverage-mocha'
```

To accomplish this, the test framework needs to tell test-bed when it starts executing a test file as well as when it finished. This means that the `test-entry.js` needs to be updated.

It’s probably not a good idea to have to update the `test-entry.js` every time a new feature (that needs integration with test framework) is added. Therefore, `test-bed` now ships with adapters for few test frameworks (only Mocha right now as we only use Mocha).

Please look at the new [README.md](https://github.com/taskworld/test-bed/blob/better-coverage-mocha/README.md#how-to-use-it) on how to create the `test-entry.js`.