### PR TITLE
Pass in webpack config file via command line parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
-const config = require(require('path').resolve(process.cwd(), 'webpack.config.test-bed.js'))
+const configFile = process.argv[2] ? process.argv[2] : 'webpack.config.test-bed.js'
+const config = require(require('path').resolve(process.cwd(), configFile))
 const server = require('./createServer')(config)
 
 server.listen(9011, function () {


### PR DESCRIPTION
In order to use different configurations within the same project, this pull request checks for the presence of a command line parameter and interprets this as the webpack.config file to use.

Possible use case: Run test-bed with different sub-sets of tests (unit and integration tests...) that also may require different configurations

This is a very simple implementation. Feel free to use a more involved implementation (using commander?) if you plan on adding other command line parameters in the future

By the way, great tool, it helps us a lot!