### PR TITLE
Pass in webpack config file via command line parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,19 @@
 #!/usr/bin/env node
 'use strict'
 
-const config = require(require('path').resolve(process.cwd(), 'webpack.config.test-bed.js'))
+const relativeConfigPath = require('yargs')
+  .option('c', {
+    alias: 'config',
+    demand: false,
+    default: 'webpack.config.test-bed.js',
+    describe: 'Specify the configuration file',
+    type: 'string'
+  })
+  .nargs('config', 1)
+  .help()
+  .argv.config;
+
+const config = require(require('path').resolve(process.cwd(), relativeConfigPath))
 const server = require('./createServer')(config)
 
 server.listen(9011, function () {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "socket.io": "^1.4.6",
     "style-loader": "^0.13.1",
     "webpack-dev-middleware": "^1.6.1",
-    "webpack-hot-middleware": "^2.10.0"
+    "webpack-hot-middleware": "^2.10.0",
+    "yargs": "^5.0.0"
   },
   "devDependencies": {
     "mocha": "^2.5.3",


### PR DESCRIPTION
@dtinth This is an improved version of my previous pull request #4 using `yargs` as you recommended.

In order to use different configurations within the same project, this pull request enables the specification of a config file via a --config command line option.

Possible use cases:
* Specify a non-standard config file location
* Run test-bed with different sub-sets of tests (unit and integration tests...) that also may require different configurations

@gkawin this should also fix #5 .