### PR TITLE
Make the port a configuration option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,33 @@
 #!/usr/bin/env node
 'use strict'
 
-const relativeConfigPath = require('yargs')
+const argv = require('yargs')
   .option('c', {
     alias: 'config',
-    demand: false,
     default: 'webpack.config.test-bed.js',
     describe: 'Specify the configuration file',
+    nargs: 1,
     type: 'string'
   })
-  .nargs('config', 1)
+  .option('p', {
+    alias: 'port',
+    default: 9011,
+    describe: 'Specify the port',
+    nargs: 1,
+    type: 'number'
+  })
   .help()
-  .argv.config
+  .argv
 
-const config = require(require('path').resolve(process.cwd(), relativeConfigPath))
+const config = require(require('path').resolve(process.cwd(), argv.config))
 const server = require('./createServer')(config)
 
-server.listen(9011, function () {
+server.listen(argv.port, function () {
   console.log('')
   console.log('++====================================================++')
   console.log('|| test-bed is now running                            ||')
   console.log('||                                                    ||')
-  console.log('|| Please open http://localhost:9011/ in your browser ||')
+  console.log(`|| Please open http://localhost:${argv.port}/ in your browser ||`)
   console.log('|| in order to run tests.                             ||')
   console.log('++====================================================++')
   console.log('')


### PR DESCRIPTION
* Together with the option to specify a configuration file, this will allow running several different instances of Test-Bed in parallel
* Also useful in case of port conflicts
* Defaults to the previously hard-coded port of 9011