### PR TITLE
add option to pass webpackMiddleware options in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,16 @@ For running in CI servers, we use Karma which works perfectly fine!
         './src',        // ← Look for test files inside `src` directory.
         true,           // ← Recurse into subdirectories.
         /\.spec\.js$/   // ← Only consider files ending in `.spec.js`.
-      )
+      ),
+
+      // Optionally, pass options through to webpack-middleware
+      webpackMiddleware: {
+        watchOptions: {
+          aggregateTimeout: 300,
+          poll: true,
+          ignore: /node_modules/
+        }
+      }
     })
     ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ For running in CI servers, we use Karma which works perfectly fine!
 
     - `entry` should be set to the test entry file. For example, `./test-entry.js`.
 
+    - optionally set `webpackMiddleware` which will be merged with some default options when we initialize webpack-middleware. This can be useful in case you need to enable polling:
+    ```
+      webpackMiddleware: {
+        watchOptions: {
+          aggregateTimeout: 300,
+          poll: true,
+          ignore: /node_modules/
+        }
+      }
+    ```
+
 3. Create a test entry file, which sets up the testing environment and sends the test context to TestBed:
 
     ```js
@@ -95,16 +106,7 @@ For running in CI servers, we use Karma which works perfectly fine!
         './src',        // ← Look for test files inside `src` directory.
         true,           // ← Recurse into subdirectories.
         /\.spec\.js$/   // ← Only consider files ending in `.spec.js`.
-      ),
-
-      // Optionally, pass options through to webpack-middleware
-      webpackMiddleware: {
-        watchOptions: {
-          aggregateTimeout: 300,
-          poll: true,
-          ignore: /node_modules/
-        }
-      }
+      )
     })
     ```
 

--- a/createServer.js
+++ b/createServer.js
@@ -68,11 +68,11 @@ module.exports = function createServer (config) {
 
   app.use(express.static(path.resolve(__dirname, 'static')))
 
-  app.use(require('webpack-dev-middleware')(compiler, {
+  app.use(require('webpack-dev-middleware')(compiler, Object.assign({
     noInfo: true,
     publicPath: '/test-assets/',
     stats: { colors: true }
-  }))
+  }, config.webpackMiddleware)))
 
   io.on('connection', function (socket) {
     debugSocket('Client connected')

--- a/createServer.js
+++ b/createServer.js
@@ -73,6 +73,7 @@ module.exports = function createServer (config) {
     publicPath: '/test-assets/',
     stats: { colors: true }
   }, config.webpackMiddleware)))
+  delete config.webpackMiddleware
 
   io.on('connection', function (socket) {
     debugSocket('Client connected')


### PR DESCRIPTION
When running in a Docker container often breaks file watching. A workaround is to tell Webpack to use polling. Rather than introduce a polling option, I thought it best to make test-bed more flexible by allowing a config object to be passed through and shallow merged with test-bed's options.

Very excited to start using this!