### PR TITLE
Add option to automatically open test-bed in the system's default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,6 @@ For running in CI servers, we use Karma which works perfectly fine!
 
     - `entry` should be set to the test entry file. For example, `./test-entry.js`.
 
-    - optionally set `webpackMiddleware` which will be merged with some default options when we initialize webpack-middleware. This can be useful in case you need to enable polling:
-    ```
-      webpackMiddleware: {
-        watchOptions: {
-          aggregateTimeout: 300,
-          poll: true,
-          ignore: /node_modules/
-        }
-      }
-    ```
-
 3. Create a test entry file, which sets up the testing environment and sends the test context to TestBed:
 
     ```js
@@ -112,6 +101,65 @@ For running in CI servers, we use Karma which works perfectly fine!
 
 4. Run `./node_modules/.bin/test-bed` and go to `http://localhost:9011/`
 
+## Webpack configuration options
+
+You can change options of the webpack middleware by adding a `webpackMiddleware` entry to `webpack.config.test-bed.js`. 
+The following code will restore the default webpack output and enable polling:
+```
+// webpack.config.test-bed.js
+module.exports = {
+  entry: ./test-entry.js
+  ... // other webpack options
+  webpackMiddleware: {
+    quiet: false,
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: true,
+      ignore: /node_modules/
+    }
+  }
+}
+```
+
+Furthermore, you can configure test-bed by adding a `testBed` entry to your `webpack.config.test-bed.js`:
+```
+// webpack.config.test-bed.js
+module.exports = {
+  ... // other webpack options
+  testBed: {
+    openBrowser: true
+  }
+}
+```
+
+Available options are:
+- `port: <portNumber>`: Change the port test-bed should use. (default is `port: 9011`)
+
+- `openBrowser: <true/false>`: Determine if test-bed should automatically try to open your systems default browser
+  (default is `openBrowser: false`)
+  
+- `configureExpressApp: <function(app, express)>`: Change the server configuration. The following code will make all
+  files in `test/resources` available under `localhost:9011/base/resources` and log all requests:
+  ```
+  configureExpressApp: function (app, express) {
+                         app.use('/base/resources', express.static('test/resources'))
+                         app.use(function (req, res, next) {
+                           console.log('Request received:', req.url)
+                           next()
+                         })
+                       }
+  ```
+
+
+## Command line options
+
+- `--help`: display available command line options
+- `-b true`, `--browser true`: automatically open test-bed in your systems default browser (can be `true` or `false`,
+  overrides setting in `webpack.config.test-bed.js`)
+- `-c myconfig.js`, `--config myconfig.js`: Use the webpack configuration given in `myconfig.js` instead of
+  `webpack.config.test-bed.js`. Allows you to e.g. use different test contexts with subsets of test.
+- `-p 9876`, `--port 9876`: Use a different port, e.g. `9876`, instead of the default of `9011`. Also overrides any port
+  specified in `webpack.config.test-bed.js`
 
 ## Appendix: How it works...
 

--- a/createServer.js
+++ b/createServer.js
@@ -69,7 +69,7 @@ module.exports = function createServer (config) {
   app.use(express.static(path.resolve(__dirname, 'static')))
 
   app.use(require('webpack-dev-middleware')(compiler, Object.assign({
-    noInfo: true,
+    quiet: true,
     publicPath: '/test-assets/',
     stats: { colors: true }
   }, config.webpackMiddleware)))

--- a/example/webpack.config.test-bed.js
+++ b/example/webpack.config.test-bed.js
@@ -25,6 +25,10 @@ module.exports = {
       }
     ]
   },
+  // Override webpack middleware default settings
+  webpackMiddleware: {
+    quiet: false
+  },
   testBed: {
     // Change this to false or remove this line to prevent your system browser from launching
     openBrowser: true,

--- a/example/webpack.config.test-bed.js
+++ b/example/webpack.config.test-bed.js
@@ -28,6 +28,8 @@ module.exports = {
   testBed: {
     // Change this to false or remove this line to prevent your system browser from launching
     openBrowser: true,
+    // Overrides the default port of 9011
+    port: 9012,
     // Optional! You can use things like `express.static()`.
     configureExpressApp: function (app, express) {
       void express

--- a/example/webpack.config.test-bed.js
+++ b/example/webpack.config.test-bed.js
@@ -26,10 +26,12 @@ module.exports = {
     ]
   },
   testBed: {
+    // Change this to false or remove this line to prevent your system browser from launching
+    openBrowser: true,
     // Optional! You can use things like `express.static()`.
     configureExpressApp: function (app, express) {
       void express
-      app.use(function(req, res, next) {
+      app.use(function (req, res, next) {
         console.log('Request received:', req.url)
         next()
       })

--- a/index.js
+++ b/index.js
@@ -16,10 +16,18 @@ const argv = require('yargs')
     nargs: 1,
     type: 'number'
   })
+  .option('b', {
+    alias: 'browser',
+    default: undefined,
+    describe: 'Specify if the system\'s default browser should be opened automatically (overrides settings in webpack config)',
+    nargs: 1,
+    type: 'boolean'
+  })
   .help()
   .argv
 
 const config = require(require('path').resolve(process.cwd(), argv.config))
+const openBrowser = argv.browser !== undefined ? argv.browser : config.testBed && config.testBed.openBrowser
 const server = require('./createServer')(config)
 
 server.listen(argv.port, function () {
@@ -27,8 +35,14 @@ server.listen(argv.port, function () {
   console.log('++====================================================++')
   console.log('|| test-bed is now running                            ||')
   console.log('||                                                    ||')
-  console.log(`|| Please open http://localhost:${argv.port}/ in your browser ||`)
-  console.log('|| in order to run tests.                             ||')
+  if (openBrowser) {
+    console.log('|| If your browser does not open automatically, visit ||')
+    console.log(`|| http://localhost:${argv.port}/ in order to run tests.      ||`)
+  } else {
+    console.log(`|| Please open http://localhost:${argv.port}/ in your browser ||`)
+    console.log('|| in order to run tests.                             ||')
+  }
   console.log('++====================================================++')
   console.log('')
+  openBrowser && require('opn')(`http://localhost:${argv.port}/`)
 })

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
+const DEFAULT_PORT = 9011
+
 const argv = require('yargs')
   .option('c', {
     alias: 'config',
@@ -11,8 +13,7 @@ const argv = require('yargs')
   })
   .option('p', {
     alias: 'port',
-    default: 9011,
-    describe: 'Specify the port',
+    describe: `Specify the port (defaults to ${DEFAULT_PORT})`,
     nargs: 1,
     type: 'number'
   })
@@ -28,21 +29,22 @@ const argv = require('yargs')
 
 const config = require(require('path').resolve(process.cwd(), argv.config))
 const openBrowser = argv.browser !== undefined ? argv.browser : config.testBed && config.testBed.openBrowser
+const port = argv.port !== undefined ? argv.port : (config.testBed && config.testBed.port) || DEFAULT_PORT
 const server = require('./createServer')(config)
 
-server.listen(argv.port, function () {
+server.listen(port, function () {
   console.log('')
   console.log('++====================================================++')
   console.log('|| test-bed is now running                            ||')
   console.log('||                                                    ||')
   if (openBrowser) {
     console.log('|| If your browser does not open automatically, visit ||')
-    console.log(`|| http://localhost:${argv.port}/ in order to run tests.      ||`)
+    console.log(`|| http://localhost:${port}/ in order to run tests.      ||`)
   } else {
-    console.log(`|| Please open http://localhost:${argv.port}/ in your browser ||`)
+    console.log(`|| Please open http://localhost:${port}/ in your browser ||`)
     console.log('|| in order to run tests.                             ||')
   }
   console.log('++====================================================++')
   console.log('')
-  openBrowser && require('opn')(`http://localhost:${argv.port}/`)
+  openBrowser && require('opn')(`http://localhost:${port}/`)
 })

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "debug": "^2.2.0",
     "express": "^4.14.0",
     "istanbul": "^0.4.3",
+    "opn": "^4.0.2",
     "raw-loader": "^0.5.1",
     "script-loader": "^0.7.0",
     "socket.io": "^1.4.6",


### PR DESCRIPTION
This pull request does the following:
* Change webpack ouput from noInfo to quiet, which seems to do a much better job of reducing noise
* Add both a configuration option and a CLI option to enable/disable automatically launching test-bed in the default browser; by default, test-bed will not open a browser thus preserving the previous behaviour. One might also consider changing the default behaviour
* Also make the port a configuration file option, not only a CLI option. That way, different configurations can automatically use different ports and thus be run side-by-side
* Update the readme to reflect all CLI and webpack configuration options

I hope you'll like this, I'm always open to suggestions. Please consider publishing a new version to NPM soon 😉